### PR TITLE
Add integration testing

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -17,6 +17,9 @@ jobs:
     - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.4'
+        bundler-cache: true
 
     - name: Publish to GPR
       run: |

--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -33,13 +33,14 @@ jobs:
         GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
         OWNER: ${{ github.repository_owner }}
 
-    - name: Publish to RubyGems
-      run: |
-        mkdir -p $HOME/.gem
-        touch $HOME/.gem/credentials
-        chmod 0600 $HOME/.gem/credentials
-        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-        gem build *.gemspec
-        gem push *.gem
-      env:
-        GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"
+    # Disable for now. May not be automatable because of 2FA
+    # - name: Publish to RubyGems
+    #   run: |
+    #     mkdir -p $HOME/.gem
+    #     touch $HOME/.gem/credentials
+    #     chmod 0600 $HOME/.gem/credentials
+    #     printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+    #     gem build *.gemspec
+    #     gem push *.gem
+    #   env:
+    #     GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,21 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
-    - name: Run tests
-      run: bundle exec rake
+    - name: Run Rubocop
+      run: bundle exec rake rubocop
+    - name: Run Unit Tests
+      run: bundle exec rake spec
+
+  integration:
+    runs-on: ubuntu-latest
+    name: Integration
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.4'
+        bundler-cache: true
+    - name: Run Integration Tests
+      run: bundle exec rake integration

--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,24 @@ RuboCop::RakeTask.new do |task|
 end
 RSpec::Core::RakeTask.new(:spec)
 
-task default: %i[rubocop spec]
+task default: %i[rubocop spec integration]
+
+desc 'Build the ONA development container with podman'
+task :build_onadev_container do
+  unless system('podman image exists localhost/ona-dev:latest')
+    `podman login docker.io`
+    `git clone https://github.com/opennetadmin/ona onadev`
+    `podman build --build-arg UBUNTU_VERSION=24.04 -t ona-dev:latest onadev`
+    `rm -rf onadev`
+  end
+end
+
+desc 'Publish ONA development container to ghcr.io'
+task publish_onadev_container_to_ghcr: :build_onadev_container do
+  `podman login ghcr.io`
+  `podman image push localhost/ona-dev:latest docker://ghcr.io/gsi-hpc/ona-dev:latest`
+end
+
+RSpec::Core::RakeTask.new(:integration) do |task|
+  task.pattern = 'integration/**{,/*/**}/*_spec.rb'
+end

--- a/integration/ona_spec.rb
+++ b/integration/ona_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'ona'
+require 'net/http'
+
+# Generate new port number each time asked
+class PortManager
+  @next_port = 11_080
+
+  def self.next_port
+    port = @next_port
+    @next_port += 1
+    port
+  end
+end
+
+def with_retries(max_retries = 30)
+  (1..max_retries).each do
+    begin
+      yield
+      return
+    rescue StandardError
+      # do nothing
+    end
+    sleep(0.2)
+  end
+  raise "max retries #{max_retries} reached, aborting"
+end
+
+def ephemeral_onadev_container
+  host = 'localhost'
+  port = PortManager.next_port
+  container_prefix = 'onadev_'
+  dcm_path = '/ona/dcm.php'
+  @dcm_endpoint = "http://#{host}:#{port}#{dcm_path}"
+  name = "#{container_prefix}#{port}"
+
+  # define and start ephemeral (--rm) container
+  `podman container create -p #{port}:80 --name #{name} --rm docker://ghcr.io/gsi-hpc/ona-dev:latest`
+  `podman container start #{name}`
+
+  # wait for webserver
+  with_retries do
+    res = Net::HTTP.start(host, port).get(dcm_path)
+    raise unless res.is_a?(Net::HTTPSuccess)
+  end
+
+  yield
+ensure
+  `podman container kill #{name}`
+end
+
+describe ONA do
+  subject(:ona) { described_class.new(@dcm_endpoint, 'admin', 'admin') } # rubocop:disable RSpec/InstanceVariable
+
+  around { |ex| ephemeral_onadev_container(&ex) }
+
+  describe 'get_module_list' do
+    subject(:result) { ona.query('get_module_list', { type: 'array' }) }
+
+    it 'returns the module list' do
+      expect(result).to be_an_instance_of(Hash).and \
+        include('domain_display')
+    end
+  end
+
+  describe 'domain_display' do
+    subject(:result) { ona.query('domain_display', { domain: 'example.com' }) }
+
+    it { is_expected.to include('fqdn' => 'example.com') }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,4 +29,6 @@ RSpec.configure do |config|
   # inherited by the metadata hash of host groups and examples, rather than
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  config.formatter = :documentation
 end


### PR DESCRIPTION
Almost no coverage, but to lay the foundation of test coverage to grow.

Want to add it to the github workflow test, but I am missing permissions to upload the onadev container to GSI-HPC currently.

One can run the integration test suite via `bundle exec rake integration` locally, needs `podman` and `git` installed.